### PR TITLE
Add include 'atomic' to avoid compilation failed on Ubuntu 16.04 OS

### DIFF
--- a/whisper.cpp
+++ b/whisper.cpp
@@ -16,7 +16,7 @@
 #include <fstream>
 #include <sstream>
 #include <thread>
-
+#include <atomic>
 #if defined(__cpp_lib_filesystem)
   #include <filesystem>
   namespace FileSystem = std::filesystem;


### PR DESCRIPTION
Accoriding to
https://github.com/westerndigitalcorporation/swerv-ISS/issues/20 and
https://github.com/chipsalliance/SweRV-ISS/commit/7b54b45af4eb63fff4a843a2c50bb50e75600806

Add atomic to whisper.cpp to prevent compiling failed at Ubuntu 16.04
with g++ 7.5