### PR TITLE
Added conditional inclusion of emmintrin.h

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,6 +17,9 @@ STATIC_LINK := 1
 # Or run make with these options
 # $ make CC=gcc-8 CXX=g++-8 AR=gcc-ar-8
 
+# Set to desired arch or set to "" when cross-compiling
+ARCH_FLAGS ?= -march=native -mtune=native
+
 # We use boost 1.67.
 # Set the BOOST_ROOT environment variable to point to the base install
 # location of the Boost Libraries
@@ -87,9 +90,9 @@ IFLAGS := $(addprefix -isystem ,$(BOOST_INC)) -I.
 
 # Command to compile .cpp files.
 ifeq (CYGWIN_NT-10.0,$(shell uname -s))
-override CXXFLAGS += -MMD -MP -mtune=native -std=c++17 -D_GNU_SOURCE $(OFLAGS) $(IFLAGS) -pedantic -Wall -Wextra
+override CXXFLAGS += -MMD -MP ${ARCH_FLAGS} -std=c++17 -D_GNU_SOURCE $(OFLAGS) $(IFLAGS) -pedantic -Wall -Wextra
 else
-override CXXFLAGS += -MMD -MP -mtune=native -std=c++17 $(OFLAGS) $(IFLAGS) -fPIC -pedantic -Wall -Wextra
+override CXXFLAGS += -MMD -MP ${ARCH_FLAGS} -std=c++17 $(OFLAGS) $(IFLAGS) -fPIC -pedantic -Wall -Wextra
 endif
 
 # Rule to make a .o from a .cpp file.

--- a/float.cpp
+++ b/float.cpp
@@ -18,7 +18,10 @@
 
 #include <cfenv>
 #include <cmath>
+#if defined(__x86_64__) || defined(_M_X64) || defined(i386) || \
+    defined(__i386__) || defined(__i386) || defined(_M_IX86)
 #include <emmintrin.h>
+#endif
 #include <array>
 #include "Hart.hpp"
 #include "instforms.hpp"
@@ -338,9 +341,12 @@ setSimulatorRoundingMode(RoundingMode mode)
 void
 clearSimulatorFpFlags()
 {
+#if defined(__x86_64__) || defined(_M_X64) || defined(i386) || \
+    defined(__i386__) || defined(__i386) || defined(_M_IX86)
   uint32_t val = _mm_getcsr();
   val &= ~uint32_t(0x3f);
   _mm_setcsr(val);
+#endif
   // std::feclearexcept(FE_ALL_EXCEPT);
 }
 


### PR DESCRIPTION
This PR should fix compilation on ARM (and possibly other non-x86) architectures by adding conditional inclusion of the SSE2 `emmintrin.h` library. Fixes 
https://github.com/chipsalliance/VeeR-ISS/issues/25